### PR TITLE
Fix non-integer PLACE rule values breaking scale inference

### DIFF
--- a/rust/src/reader.rs
+++ b/rust/src/reader.rs
@@ -1,6 +1,8 @@
 use arrow::array::{RecordBatch, RecordBatchReader};
-use arrow::compute::concat_batches;
+use arrow::compute::{cast, concat_batches};
+use arrow::datatypes::{DataType, Field, Schema};
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
+use std::sync::Arc;
 use ggsql::reader::{execute_with_reader, Reader, Spec, SqlDialect};
 use ggsql::{DataFrame, GgsqlError, Result};
 
@@ -56,8 +58,54 @@ impl CallbackReader {
                 .map_err(|e| GgsqlError::ReaderError(format!("arrow concat_batches failed: {}", e)))?
         };
 
+        let batch = normalize_arrow_types(batch)?;
         Ok(DataFrame::from_record_batch(batch))
     }
+}
+
+/// Cast Decimal columns to Float64 so ggsql's scale inference sees numeric types.
+///
+/// DuckDB types fractional literals in VALUES/SELECT as DECIMAL (e.g. PLACE rule
+/// `SETTING x => 21.5`). ggsql treats unknown Arrow types as strings, which flips
+/// position scales to discrete and can break histogram binning. The bundled
+/// DuckDBReader in ggsql already normalizes decimals; mirror that here.
+fn normalize_arrow_types(batch: RecordBatch) -> Result<RecordBatch> {
+    let schema = batch.schema();
+    let needs_cast = schema
+        .fields()
+        .iter()
+        .any(|f| matches!(f.data_type(), DataType::Decimal128(_, _)));
+
+    if !needs_cast {
+        return Ok(batch);
+    }
+
+    let mut new_fields = Vec::with_capacity(schema.fields().len());
+    let mut new_columns = Vec::with_capacity(batch.num_columns());
+
+    for (i, field) in schema.fields().iter().enumerate() {
+        if matches!(field.data_type(), DataType::Decimal128(_, _)) {
+            let casted = cast(batch.column(i), &DataType::Float64).map_err(|e| {
+                GgsqlError::ReaderError(format!(
+                    "failed to cast column '{}' from Decimal to Float64: {}",
+                    field.name(),
+                    e
+                ))
+            })?;
+            new_fields.push(Field::new(
+                field.name(),
+                DataType::Float64,
+                field.is_nullable(),
+            ));
+            new_columns.push(casted);
+        } else {
+            new_fields.push(field.as_ref().clone());
+            new_columns.push(batch.column(i).clone());
+        }
+    }
+
+    RecordBatch::try_new(Arc::new(Schema::new(new_fields)), new_columns)
+        .map_err(|e| GgsqlError::ReaderError(format!("failed to normalize arrow types: {}", e)))
 }
 
 impl Reader for CallbackReader {

--- a/test/sql/ggsql.test
+++ b/test/sql/ggsql.test
@@ -89,3 +89,32 @@ RESET ggsql_output;
 # no result set at all.
 statement ok
 SELECT 1 AS x, 2 AS y VISUALISE x, y DRAW point;
+
+# --------------------------------------------------------------------------------
+# Issue #13: non-integer PLACE rule positions must not break scale inference.
+# DuckDB types fractional literals as DECIMAL; without normalization ggsql treats
+# them as strings and flips position scales to discrete (or breaks histograms).
+# --------------------------------------------------------------------------------
+statement ok
+SET ggsql_output = 'spec';
+
+statement ok
+SELECT ggsql('
+  SELECT CAST(random() * 50 AS DOUBLE) AS x_val, CAST(random() * 50 AS DOUBLE) AS y_val
+  FROM range(50)
+  VISUALISE x_val AS x, y_val AS y
+  DRAW point
+  PLACE rule SETTING x => 21.5
+');
+
+statement ok
+SELECT ggsql('
+  SELECT CAST(20 + 40 * random() AS DOUBLE) AS value
+  FROM range(500)
+  VISUALISE value AS x
+  DRAW histogram
+  PLACE rule SETTING x => 44.4
+');
+
+statement ok
+RESET ggsql_output;


### PR DESCRIPTION
## Summary
- Normalize DuckDB DECIMAL Arrow columns to Float64 in `CallbackReader`
- Fixes fractional `PLACE rule` positions (e.g. `x => 21.5`) incorrectly flipping position scales to discrete or breaking histogram binning
- Add SQL logic test coverage for point + histogram cases from #13

Fixes #13

## Test plan
- [x] `GGSQL_NO_OPEN_BROWSER=1 make test`
- [x] Manual verification of point + histogram queries with non-integer PLACE rule values

Made with [Cursor](https://cursor.com)